### PR TITLE
Python script to combine and split docs for google translate

### DIFF
--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -1,3 +1,4 @@
 **/*.src
 **/*.src.docx
 **/*.src.xlsx
+**/*.docx

--- a/utils/src-docx-tool/config.json
+++ b/utils/src-docx-tool/config.json
@@ -1,0 +1,4 @@
+{
+    "script_folder": "../../original-script"
+  }
+  

--- a/utils/src-docx-tool/config.json
+++ b/utils/src-docx-tool/config.json
@@ -1,4 +1,4 @@
 {
-    "script_folder": "../../original-script"
-  }
+  "script_folder": "../../script"
+}
   

--- a/utils/src-docx-tool/src_docx_tool.py
+++ b/utils/src-docx-tool/src_docx_tool.py
@@ -1,0 +1,106 @@
+import os
+import argparse
+import json
+from pathlib import Path
+from docx import Document
+from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
+
+ENCODING = 'shift_jis'
+CONFIG_FILE = 'config.json'
+
+def combine_src_to_docx(output_filename):
+    doc = Document()
+    for file in Path('.').glob('*.src'):
+        doc.add_paragraph(file.name).alignment = WD_PARAGRAPH_ALIGNMENT.CENTER
+        doc.add_paragraph('-' * 40)
+
+        with file.open('r', encoding=ENCODING, errors='ignore') as f:
+            for line in f:
+                doc.add_paragraph(line.strip())
+
+        doc.add_page_break()
+
+    doc.save(output_filename)
+    print(f"Combined .src files into {output_filename}")
+
+def split_docx_to_src(input_filename):
+    # Load config
+    if not Path(CONFIG_FILE).exists():
+        print(f"Config file '{CONFIG_FILE}' not found.")
+        return
+
+    with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+        config = json.load(f)
+
+    script_folder = Path(config.get('script_folder', '.'))
+    if not script_folder.exists():
+        print(f"Script folder '{script_folder}' not found.")
+        return
+
+    doc = Document(input_filename)
+    src_files = {}
+    current_filename = None
+    content_lines = []
+
+    for para in doc.paragraphs:
+        if para.text.endswith('.src') and len(para.text.strip()) > 4:
+            if current_filename and content_lines:
+                src_files[current_filename] = content_lines
+            current_filename = para.text.strip()
+            content_lines = []
+        elif para.text == '-' * 40 or para.text.strip() == '':
+            continue
+        else:
+            content_lines.append(para.text)
+
+    if current_filename and content_lines:
+        src_files[current_filename] = content_lines
+
+    for filename, new_lines in src_files.items():
+        original_path = script_folder / filename
+        if not original_path.exists():
+            print(f"Original script not found: {original_path}")
+            continue
+
+        with original_path.open('r', encoding=ENCODING, errors='ignore') as f:
+            original_lines = f.readlines()
+
+        replaced_lines = []
+        new_line_iter = iter(new_lines)
+        for line in original_lines:
+            stripped = line.lstrip()
+            if stripped.startswith(';') or stripped.startswith('#'):
+                try:
+                    replacement = next(new_line_iter)
+                    replaced_lines.append(replacement + '\n')
+                except StopIteration:
+                    replaced_lines.append(line)
+            else:
+                replaced_lines.append(line)
+
+        with open(filename, 'w', encoding=ENCODING, errors='ignore') as f:
+            f.writelines(replaced_lines)
+
+        print(f"Created {filename} with replaced lines.")
+
+def main():
+    parser = argparse.ArgumentParser(description="Combine or split .src files and .docx documents.")
+    subparsers = parser.add_subparsers(dest='command')
+
+    combine_parser = subparsers.add_parser('combine', help='Combine all .src files into a .docx')
+    combine_parser.add_argument('output', help='Output .docx filename')
+
+    split_parser = subparsers.add_parser('split', help='Split .docx into .src files with line replacements')
+    split_parser.add_argument('input', help='Input .docx filename')
+
+    args = parser.parse_args()
+
+    if args.command == 'combine':
+        combine_src_to_docx(args.output)
+    elif args.command == 'split':
+        split_docx_to_src(args.input)
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Idea to combine all the script files together so that I can do google translate in one shot, then split it up afterwards. 

- Possible to do this easily because Chatgpt released after 2022-Nov, which was after I dropped this project - with chatgpt, it is easier to write python scripts
- Google translate allows up to 10 MB per file, and total file size of scripts isn't that huge
- This saves me time instead of dragging each individual script and downloading each time, lots of clicks

Also found an increase in quality of machine translations, so will be generating the mtl-script folder again of the remaining scripts
Besides the issue of pronouns you I me he her she him, or 子 translating to girl instead of boy, due to the vagueness of Japanese language, it seems very accurate.

Will need to edit pronouns. Will also do a search to find and replace gender pronouns. But girl sometimes is used in kink scenes like a girl, so shouldn't mass replace it.

Did I mention that I still have to understand chatgpt's code to fix line break issue? Ugh. But still saved me a lot of work, thanks chatgpt.